### PR TITLE
fix: UnicodeDecodeError and UnicodeEncodeError when reading/writing files with unsupported characters

### DIFF
--- a/userid-check.py
+++ b/userid-check.py
@@ -738,12 +738,12 @@ console.print(results_table)
 
 if args.w:
     console.save_html(html_file)
-    with open(html_file, 'r') as file:
+    with open(html_file, 'r', encoding='utf-8') as file:
       filedata = file.read()
 
     filedata = filedata.replace('<body>', '<body><center>').replace('</body>', '</body></center>')
 
-    with open(html_file, 'w') as file:
+    with open(html_file, 'w', encoding='utf-8') as file:
       file.write(filedata)
 else:
     pass


### PR DESCRIPTION
## Description
This PR addresses UnicodeDecodeError and UnicodeEncodeError that occur when the script tries to read and write files containing characters not supported by the system's default encoding (cp1253 on Windows systems). The errors are resolved by explicitly specifying utf-8 encoding when opening files for reading and writing.

Code changes:
Line 741:

```python
with open(html_file, 'r', encoding='utf-8') as file:
```
Line 746:

```python
with open(html_file, 'w', encoding='utf-8') as file:
```
## Motivation and Context
This change is required to prevent errors when handling files with non-ASCII characters. Without specifying the encoding, the script throws UnicodeDecodeError and UnicodeEncodeError on systems that default to cp1253. This PR solves these issues and allows the script to handle files with a broader range of characters, ensuring cross-platform compatibility.

## How Has This Been Tested?
The changes were tested by running the script on a Windows system with utf-8 encoded files containing various non-ASCII characters. The script successfully read and wrote the files without raising any errors. No other parts of the script were affected by this change.

## Screenshots (if appropriate)
![bug](https://github.com/user-attachments/assets/db813939-6f9d-466e-8a52-3753f7de536a)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
